### PR TITLE
Add initial project statistics

### DIFF
--- a/src/bin/helpers.rs
+++ b/src/bin/helpers.rs
@@ -134,6 +134,7 @@ pub fn create_matches<'a>() -> (ArgMatches<'a>, String, String) {
         static ref LIST_OPTIONS_MD: String = lformat!("List all possible options, formatted in Markdown");
         static ref PRINT_TEMPLATE: String = lformat!("Prints the default content of a template");
         static ref BOOK: String = lformat!("File containing the book configuration file, or a Markdown file when called with --single");
+        static ref STATS: String = lformat!("Print some project statistics");
         static ref TEMPLATE: String = lformat!("\
 {{bin}} {{version}} by {{author}}
 {{about}}
@@ -193,6 +194,7 @@ ARGS:
         .arg(Arg::from_usage("-L --lang [LANG]")
              .help(LANG.as_str()))
         .arg(Arg::from_usage("--print-template [TEMPLATE]").help(PRINT_TEMPLATE.as_str()))
+        .arg(Arg::from_usage("--stats -S").help(STATS.as_str()))
         .arg(Arg::with_name("BOOK")
             .index(1)
             .help(BOOK.as_str()))

--- a/src/bin/real_main.rs
+++ b/src/bin/real_main.rs
@@ -21,6 +21,7 @@ use helpers::*;
 
 use crowbook::{Result, Book, BookOptions, InfoLevel};
 use crowbook_intl_runtime::set_lang;
+use crowbook::Stats;
 use clap::ArgMatches;
 use std::process::exit;
 use std::io;
@@ -155,6 +156,13 @@ pub fn try_main() -> Result<()> {
     }
 
     set_book_options(&mut book, &matches);
+
+    if matches.is_present("stats") {
+        let stats = Stats::new(&book);
+        println!("{}", stats);
+        exit(0);
+    }
+
     if let Some(format) = matches.value_of("to") {
         render_format(&mut book, &matches, format);
     } else {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -143,6 +143,7 @@ pub use logger::{Logger, InfoLevel};
 pub use renderer::Renderer;
 pub use book_renderer::BookRenderer;
 pub use chapter::Chapter;
+pub use stats::Stats;
 
 #[macro_use]
 #[doc(hidden)]
@@ -169,6 +170,7 @@ mod book_renderer;
 mod html_single;
 mod html_if;
 mod syntax;
+mod stats;
 
 mod zipper;
 mod templates;

--- a/src/lib/stats.rs
+++ b/src/lib/stats.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2017 Élisabeth HENRY.
+//
+// This file is part of Crowbook.
+//
+// Crowbook is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// Crowbook is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Crowbook.  If not, see <http://www.gnu.org/licenses/>.
+use book::Book;
+use text_view::view_as_text;
+
+use std::fmt;
+
+pub struct Stats {
+  chapter_word_counts: Vec<(String, usize)>
+}
+
+impl Stats {
+  pub fn new(book: &Book) -> Stats {
+    let mut stats = Stats{ chapter_word_counts: vec!() };
+    for c in &book.chapters {
+      let count = view_as_text(&c.content).split_whitespace().count();
+      stats.chapter_word_counts.push((c.filename.clone(), count));
+    }
+    stats
+  }
+}
+
+impl fmt::Display for Stats {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "Chapter word counts:\n---------\n")?;
+    for c in &self.chapter_word_counts {
+      write!(f, "{:<30} {:>5}\n", c.0, c.1)?;
+    }
+    let total = self.chapter_word_counts.iter().fold(0, |acc, &(_, n)| acc +n);
+    write!(f, "---------\nTOTAL:{:>30}\n", total)
+  }
+}


### PR DESCRIPTION
For now only chapterwise word counts and total wordcount. 

It looks like this:

```
$> crowbook -S guide.book

Chapter word counts:
---------
README.md                       1203
guide/arguments.md               817
guide/config.md                 3699
guide/markdown.md                407
guide/templates.md               932
guide/proofreading.md            512
guide/if.md                      696
guide/misc.md                    299
guide/contribute.md              176
ChangeLog.md                    4122
LICENSE.md                      4297
---------
TOTAL:                         17160
```