### PR TITLE
fix (main,book_bars,helpers): fix cargo warnings

### DIFF
--- a/src/bin/helpers.rs
+++ b/src/bin/helpers.rs
@@ -1,6 +1,6 @@
 use crowbook::Book;
 use clap::{App, Arg,  ArgMatches, AppSettings};
-use console::{style, Emoji};
+use console::style;
 
 use std::io::{self, Write};
 use std::process::exit;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,6 @@
 extern crate crowbook;
 extern crate crowbook_intl_runtime;
 extern crate console;
-#[macro_use]
 extern crate log;
 
 #[cfg(feature= "binary")]

--- a/src/lib/book_bars.rs
+++ b/src/lib/book_bars.rs
@@ -23,7 +23,6 @@ use book::Book;
 use indicatif::{ProgressBar, ProgressStyle, MultiProgress};
 use std::sync::Arc;
 use std::thread;
-use std::mem;
 
 impl Book {
     /// Adds a progress bar where where info should be written.


### PR DESCRIPTION
Fixed unused import warnings:

* unused import: `std::mem`
* unused `#[macro_use]` import
* unused import: `Emoji`