### PR TITLE
Bump crowbook version in lib.rs

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -26,7 +26,7 @@
 //! default features that are mostly useful for the binary:
 //!
 //! ```ignore
-//! crowbook = {version = "0.11", default-features = false}
+//! crowbook = {version = "0.14.1", default-features = false}
 //! ```
 //!
 //! # Book


### PR DESCRIPTION
lib.rs was out of date with release version, resulting in misleading documentation on https://docs.rs/crowbook/0.14.1/crowbook/