### PR TITLE
Compile fix for extended stats feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ doc = false
 default = ["binary", "proofread", "syntect"]
 proofread = ["caribon", "reqwest", "url", "serde", "serde", "serde_json", "serde_derive"]
 binary = ["clap", "simplelog", "tempdir", "console", "indicatif", "textwrap"]
-nightly = ["punkt"]
+nightly = ["punkt", "hyphenation"]
 
 [build-dependencies]
 crowbook-intl = "0.2"


### PR DESCRIPTION
Sorry, there's also some `rustfmt` changes. I can remove them if you'd like to keep old formatting.