### PR TITLE
Fix remaining references to guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,18 @@ This is mostly useful when Crowbook is run with the `--single` argument (receivi
 
 Crowbook can also generate "proofreading" copies in HTML or PDF, highlighting grammar errors and repetitions.
 For more information, see
-[the proofreading chapter of the guide](guide/proofreading.md).
+[the proofreading chapter of the guide](guide/05_proofreading.md).
 
 ### Interactive fiction
 
 Crowbook has experimental support for writing interactive fiction (only for HTML).
 For more information, read the
-[interactive fiction chapter](guide/if.md).
+[interactive fiction chapter](guide/06_interactive_fiction.md).
 
 ### Customization
 
 While the default settings will hopefully generate something that should look "good enough", it is possible to customize the output, essentially by providing different
-[templates](guide/templates.md).
+[templates](guide/04_templates.md).
 
 ### Bugs
 
@@ -224,7 +224,7 @@ See [ChangeLog](ChangeLog.md).
 
 ## Contributing
 
-See [how you can contribute to Crowbook](guide/contribute.md).
+See [how you can contribute to Crowbook](guide/08_contributing.md).
 
 If you find this project useful, you can also support its author by
 [making a Paypal donation](https://www.paypal.me/crowdagger).

--- a/guide/01_arguments.md
+++ b/guide/01_arguments.md
@@ -122,7 +122,7 @@ crowbook <BOOK> --set [KEY] [VALUE]...
 
 This argument takes a list of  `KEY` `VALUE` pairs and allows setting or overriding a book configuration option.
 All valid options in the configuration files are valid as keys.
-For more information, see [the configuration file](config.md).
+For more information, see [the configuration file](02_config.md).
 
 ```bash
 $ crowbook foo.book --set tex.paper.size a4paper
@@ -197,7 +197,7 @@ crowbook -p <BOOK>
 ```
 
 Equivalent to `--set proofread true`, enables proofreading.
-See [Proofreading](proofreading.md).
+See [Proofreading](05_proofreading.md).
 
 ## `--autograph`
 

--- a/guide/02_config.md
+++ b/guide/02_config.md
@@ -222,7 +222,7 @@ There are also additional metadata:
 You can define your own metadata by starting an option name with `metadata.foo`.
 
 All metadata are accessible from templates, see
-[Templates](templates.md).
+[Templates](04_templates.md).
 
 ### The `import` special option
 
@@ -300,9 +300,9 @@ Current output options are:
 * `output.pdf`: renders a PDF file (using `tex.command`).
 
 (There are other output options for generating proofreading files, see
-[Proofreading](proofreading.md),
+[Proofreading](05_proofreading.md),
 and interactive fiction, see
-[Interactive fiction](if.md).)
+[Interactive fiction](06_interactive_fiction.md).)
 
 #### The `output` option
 
@@ -429,7 +429,7 @@ These options allow you to customize the HTML rendering (used both by the defaul
   allow to set a custom (Markdown) string at the top and at the bottom of the HTML page.
   This is actually a template, so you can access metadata, such as `{{{author}}}`, `{{{title}}}`, or `{{{version}}}` in it.
   See the
-  [template](templates.md)
+  [template](04_templates.md)
   chapter for more information on the fields you can use.
 * `html.css`:
   allows to set up a custom CSS file.

--- a/guide/03_markdown.md
+++ b/guide/03_markdown.md
@@ -104,4 +104,4 @@ While this one ![Logo](../img/crowbook-small.png) is embedded in a paragraph and
 
 `crowbook` also adds some syntax for interactive fiction, to make embedding Javascript code easier.
 It is only enabled for the interactive fiction renderer.
-For more information, see the [chapter on this matter](if.md).
+For more information, see the [chapter on this matter](06_interactive_fiction.md).


### PR DESCRIPTION
The filenames of the guide have been renamed in 0d1ea8f but not all references have been updated accordingly.