### PR TITLE
Correct example for inline template

### DIFF
--- a/guide/04_templates.md
+++ b/guide/04_templates.md
@@ -32,7 +32,7 @@ html.css.add: "h1 { background-color: red; }"
 epub.css.add: "h1 { background-color: gray; }"
 
 # LaTeX code added to default LaTeX template (but doesn't override it)
-template.tex.add: "\usepackage{libertineotf}"
+tex.template.add: "\\usepackage{libertineotf}"
 ```
 
 most templates must be in a separate file:


### PR DESCRIPTION
The key used for `tex.template` was wrong and the `\` wasn't escaped