### PR TITLE
Override titlepage template epub

### DIFF
--- a/guide/04_templates.md
+++ b/guide/04_templates.md
@@ -183,6 +183,10 @@ The main (and currently only) template used by the LaTeX renderer.
 This template is the main template used by the Epub renderer.
 It contains the XHTML template that will be used for each chapter.
 
+### epub.titlepage.xhtml
+
+This template is the template used by the Epub renderer for the title page.
+
 ### epub.css
 
 This template is used by the Epub renderer and contains the style sheet.

--- a/src/lib/book.rs
+++ b/src/lib/book.rs
@@ -1303,10 +1303,18 @@ impl Book {
     #[doc(hidden)]
     pub fn get_template(&self, template: &str) -> Result<Cow<'static, str>> {
         let option = self.options.get_path(template);
+        let epub3 = template.starts_with("epub") && self.options.get_i32("epub.version")? == 3;
         let fallback = match template {
             "epub.css" => epub::CSS,
+            "epub.titlepage.xhtml" => {
+                if epub3 {
+                    epub3::TITLE
+                } else {
+                    epub::TITLE
+                }
+            }
             "epub.chapter.xhtml" => {
-                if self.options.get_i32("epub.version")? == 3 {
+                if epub3 {
                     epub3::TEMPLATE
                 } else {
                     epub::TEMPLATE

--- a/src/lib/book.rs
+++ b/src/lib/book.rs
@@ -1024,14 +1024,7 @@ impl Book {
 
     pub fn render_format_to_file<P: Into<PathBuf>>(&mut self, format: &str, path: P) -> Result<()> {
         let bar = self.add_spinner_to_multibar(format);
-        let path = path.into();
-        let normalized = misc::normalize(&path);
         self.render_format_to_file_with_bar(format, path, bar)?;
-        self.bar_finish(
-            Crowbar::Spinner(bar),
-            CrowbarState::Success,
-            &lformat!("generated {path}", path = normalized),
-        );
         self.bar_finish(Crowbar::Main, CrowbarState::Success, &lformat!("Finished"));
         Ok(())
     }

--- a/src/lib/bookoptions.rs
+++ b/src/lib/bookoptions.rs
@@ -97,6 +97,7 @@ epub.highlight.theme:str            # {epub_theme}
 epub.css:tpl                        # {epub_css}
 epub.css.add:str                    # {epub_css_add}
 epub.chapter.xhtml:tpl              # {chapter_xhtml}
+epub.titlepage.xhtml:tpl            # {titlepage_xhtml}
 epub.toc.extras:bool:true           # {epub_toc}
 epub.escape_nb_spaces:bool:true     # {nb_spaces}
 
@@ -294,6 +295,7 @@ crowbook.verbose:alias                              # {removed}
                                          epub_css = lformat!("Path of a stylesheet for EPUB"),
                                          epub_css_add = lformat!("Inline CSS added to the EPUB stylesheet template"),
                                          chapter_xhtml = lformat!("Path of an xhtml template for each chapter"),
+                                         titlepage_xhtml = lformat!("Path of an xhtml template for the title page"),
                                          epub_toc = lformat!("Add 'Title' and (if set) 'Cover' in the EPUB table of contents"),
 
                                          tex_links = lformat!("Add foontotes to URL of links so they are readable when printed"),

--- a/src/lib/epub.rs
+++ b/src/lib/epub.rs
@@ -288,11 +288,13 @@ impl<'a> EpubRenderer<'a> {
 
     /// Render the titlepgae
     fn render_titlepage(&mut self) -> Result<String> {
-        let epub3 = self.html.book.options.get_i32("epub.version").unwrap() == 3;
         let template = compile_str(
-            if epub3 { epub3::TITLE } else { TITLE },
+            self.html
+                .book
+                .get_template("epub.titlepage.xhtml")?
+                .as_ref(),
             &self.html.book.source,
-            "title page",
+            "epub.titlepage.xhtml",
         )?;
         let data = self
             .html


### PR DESCRIPTION
This allows to override epub.titlepage.xhtml and fixes a bug in the output message of the progress bar (the file was correctly generated).